### PR TITLE
Update example-ingress.yaml

### DIFF
--- a/example-ingress.yaml
+++ b/example-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
@@ -8,6 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - anthonycornell.com
@@ -17,10 +18,16 @@ spec:
     http:
       paths:
         - path: /apple
+          pathType: Prefix
           backend:
-            serviceName: apple-service
-            servicePort: 5678
+            service:
+              name: apple-service
+              port:
+                number: 5678
         - path: /banana
+          pathType: Prefix
           backend:
-            serviceName: banana-service
-            servicePort: 5678
+            service:
+              name: banana-service
+              port:
+                number: 5678


### PR DESCRIPTION
Updated Ingress resource definition to align with "networking.k8s.io/v1" due to API deprecations in V1.22 (Ref : https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/). 

All available future k8s release expected to have this new way of spec definition.